### PR TITLE
Provide other value to fallback in `unwrapOrElse` & `unwrapLeftOrElse`

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -69,12 +69,14 @@ export const tryCatch = <RightValue>(
   }
 }
 
-export const unwrapOrElse = <RightValue, FallbackValue>(
-  either: Either<unknown, RightValue>,
-  fallback: () => FallbackValue,
-): RightValue | FallbackValue => (isRight(either) ? either.value : fallback())
+export const unwrapOrElse = <RightValue, FallbackValue, LeftValue>(
+  either: Either<LeftValue, RightValue>,
+  fallback: (value: LeftValue) => FallbackValue,
+): RightValue | FallbackValue =>
+  isRight(either) ? either.value : fallback(either.value)
 
-export const unwrapLeftOrElse = <LeftValue, FallbackValue>(
-  either: Either<LeftValue, unknown>,
-  fallback: () => FallbackValue,
-): LeftValue | FallbackValue => (isLeft(either) ? either.value : fallback())
+export const unwrapLeftOrElse = <LeftValue, FallbackValue, RightValue>(
+  either: Either<LeftValue, RightValue>,
+  fallback: (value: RightValue) => FallbackValue,
+): LeftValue | FallbackValue =>
+  isLeft(either) ? either.value : fallback(either.value)


### PR DESCRIPTION
I should've done it this way initially, but my initial use cases involved falling back to a static value so I overlooked it.